### PR TITLE
Add 'live_restore' property to 'docker_service'

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,6 +398,7 @@ The `docker_service` resource property list mostly corresponds to the options fo
 - `tmpdir` - ENV variable set before for Docker daemon starts
 - `userland_proxy`- Enables or disables docker-proxy
 - `userns_remap` - Enable user namespace remapping options - `default`, `uid`, `uid:gid`, `username`, `username:groupname` (see: [Docker User Namespaces](see: https://docs.docker.com/v1.10/engine/reference/commandline/daemon/#daemon-user-namespace-options))
+- `live_restore` - Keep containers alive during daemon downtime (see: [Live restore](https://docs.docker.com/config/containers/live-restore))
 - `version` - Docker version to install
 
 #### Miscellaneous Options

--- a/libraries/docker_service_base.rb
+++ b/libraries/docker_service_base.rb
@@ -63,6 +63,7 @@ module DockerCookbook
     property :userland_proxy, [TrueClass, FalseClass]
     property :disable_legacy_registry, [TrueClass, FalseClass]
     property :userns_remap, String
+    property :live_restore, [TrueClass, FalseClass], default: false
 
     # These are options specific to systemd configuration such as
     # LimitNOFILE or TasksMax that you may wannt to use to customize

--- a/libraries/helpers_service.rb
+++ b/libraries/helpers_service.rb
@@ -229,6 +229,7 @@ module DockerCookbook
         opts << "--userland-proxy=#{userland_proxy}" unless userland_proxy.nil?
         opts << "--disable-legacy-registry=#{disable_legacy_registry}" unless disable_legacy_registry.nil?
         opts << "--userns-remap=#{userns_remap}" if userns_remap
+        opts << '--live-restore' if live_restore
         opts << misc_opts if misc_opts
         opts
       end


### PR DESCRIPTION
### Description

Option `--live-restore` is for keeping containers alive during daemon downtime
Defaults to `false`
More information: https://docs.docker.com/config/containers/live-restore/

### Check List

- [ ] All tests pass. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/TESTING.MD>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
- [ ] All commits have been signed for the Developer Certificate of Origin. See <https://github.com/chef-cookbooks/community_cookbook_documentation/blob/master/CONTRIBUTING.MD>
